### PR TITLE
feat: add phase 1 api v2 listing endpoints

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-05-10
+          toolchain: nightly-2025-07-01
           targets: x86_64-unknown-linux-musl
 
       - name: Install musl-tools (musl-gcc)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Fork了[Anna Clemens](https://git.anna.lgbt/ascclemens/remote-party-finder)的Re
 ## API
 已经提供了 API，使用方式请见 [API 使用文档](https://github.com/LittleNightmare/remote-party-finder/wiki/API-Usage)。
 
+### API v2 phase 1
+
+This repo now ships a parallel read API under `/api/v2`.
+
+- v1 stays available. v2 is additive and runs in parallel during migration.
+- Phase 1 exposes only `GET /api/v2/listings` and `GET /api/v2/listings/{id}`.
+- Listing resources are IDs-only for lookup-backed fields such as worlds, categories, duties, jobs, objectives, conditions, loot rules, and slot roles.
+- Phase 1 has no `/api/v2/lookups/*` routes. Clients must resolve labels outside this API.
+- `/api/v2/listings/{id}` is an active-detail lookup alias for the current visible PF listing id. It is not a durable historical identity.
+
+See [`docs/api-v2.md`](docs/api-v2.md) for the phase-1 contract, examples, and migration notes.
+
 ## 前端
 可以查看利用 API 的前端项目：[remote-party-finder-frontend](https://github.com/Cindy-Master/remote-party-finder-frontend)。
 

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -1,0 +1,157 @@
+# API v2, phase 1 contract
+
+`/api/v2` is a new read surface that runs alongside the existing v1 API.
+
+## Scope
+
+Phase 1 exposes only these routes:
+
+- `GET /api/v2/listings`
+- `GET /api/v2/listings/{id}`
+
+Phase 1 does not expose lookup routes. `/api/v2/lookups/*` does not exist. World names, duty names, category labels, job labels, and other lookup-backed text must be resolved outside this API.
+
+## Contract rules
+
+- v1 stays available. Do not treat v1 as deprecated or removed.
+- v2 is IDs-only for lookup-backed references.
+- `player_name` and `description` stay inline text.
+- Unknown but well-formed filter ids return `200` with an empty `data` array.
+- Unsupported legacy label filters return `400 invalid_query`.
+- `/api/v2/listings/{id}` resolves the current active visible PF listing by listing id. It is an active-detail lookup alias, not a durable storage identity.
+- Missing, expired, or non-visible ids return `404 not_found`.
+
+## `GET /api/v2/listings`
+
+Supported query parameters in phase 1:
+
+- `page`
+- `per_page`
+- `search`
+- `created_world_id`
+- `home_world_id`
+- `category_id`
+- `duty_id`
+- `job_ids`
+
+Summary item shape:
+
+```json
+{
+  "id": 900001,
+  "player_name": "Alice",
+  "description": "Need clear",
+  "created_world_id": 1167,
+  "home_world_id": 1167,
+  "category_id": 64,
+  "duty_id": 1234,
+  "duty_type_id": 0,
+  "min_item_level": 710,
+  "slots_filled": 6,
+  "slots_available": 8,
+  "time_left_seconds": 1200,
+  "updated_at": "2026-04-23T12:34:56Z",
+  "is_cross_world": true,
+  "beginners_welcome": false
+}
+```
+
+Collection response example:
+
+```json
+{
+  "data": [
+    {
+      "id": 900001,
+      "player_name": "Alice",
+      "description": "Need clear",
+      "created_world_id": 1167,
+      "home_world_id": 1167,
+      "category_id": 64,
+      "duty_id": 1234,
+      "duty_type_id": 0,
+      "min_item_level": 710,
+      "slots_filled": 6,
+      "slots_available": 8,
+      "time_left_seconds": 1200,
+      "updated_at": "2026-04-23T12:34:56Z",
+      "is_cross_world": true,
+      "beginners_welcome": false
+    }
+  ],
+  "pagination": {
+    "total": 1,
+    "page": 1,
+    "per_page": 20,
+    "total_pages": 1
+  }
+}
+```
+
+Example requests:
+
+- `GET /api/v2/listings`
+- `GET /api/v2/listings?search=clear&job_ids=24,28`
+- `GET /api/v2/listings?created_world_id=1167&category_id=64`
+
+Avoid old label-based queries such as `world=` or `category=`. Use numeric ids instead.
+
+## `GET /api/v2/listings/{id}`
+
+Detail response example:
+
+```json
+{
+  "data": {
+    "id": 900001,
+    "player_name": "Alice",
+    "description": "Need clear",
+    "created_world_id": 1167,
+    "home_world_id": 1167,
+    "category_id": 64,
+    "duty_id": 1234,
+    "duty_type_id": 0,
+    "min_item_level": 710,
+    "slots_filled": 6,
+    "slots_available": 8,
+    "time_left_seconds": 1200,
+    "updated_at": "2026-04-23T12:34:56Z",
+    "is_cross_world": true,
+    "beginners_welcome": false,
+    "objective_ids": [1, 4],
+    "condition_ids": [2],
+    "loot_rule_id": 3,
+    "slots": [
+      {
+        "filled": true,
+        "role_id": 3,
+        "filled_job_id": 19,
+        "accepted_job_ids": []
+      },
+      {
+        "filled": false,
+        "role_id": 2,
+        "filled_job_id": null,
+        "accepted_job_ids": [24, 28]
+      }
+    ]
+  }
+}
+```
+
+Use this route as a lookup for the current active PF listing id only. If a listing expires, becomes non-visible, or is replaced by a newer active row for the same PF id, this route follows the current active row.
+
+## Migration guidance for external clients
+
+If you already consume v1:
+
+1. Keep existing v1 integrations running while you add v2 support.
+2. Switch list and detail reads to `/api/v2/listings` and `/api/v2/listings/{id}`.
+3. Replace label-based parsing with id-based parsing for worlds, duties, categories, jobs, objectives, conditions, loot rules, and slot roles.
+4. Move label resolution into your own lookup tables, frontend assets, or another metadata source.
+5. Treat `/api/v2/listings/{id}` as active listing lookup semantics, not as a stable historical key.
+
+If you are starting fresh:
+
+- Prefer v2 for new read clients that already have an external metadata source.
+- Use v1 only if you still depend on inline labels from the old response shape.

--- a/server/src/api_v2_contract.rs
+++ b/server/src/api_v2_contract.rs
@@ -1,0 +1,1139 @@
+use serde_json::json;
+use warp::http::StatusCode;
+use mongodb::bson::doc;
+
+use crate::listing::{
+    ConditionFlags, DutyCategory, DutyType, JobFlags, LootRuleFlags, ObjectiveFlags,
+};
+use crate::listing_container::QueriedListing;
+use crate::web::v2::contracts::{
+    CollectionEnvelope, ErrorEnvelope, ListingDetail, ListingMemberResponse, ListingSlot,
+    ListingSummary, Pagination,
+};
+use crate::web::v2::filters::ListingsQuery;
+use crate::web::v2::id_inventory;
+use crate::web::v2::listings::{
+    collection_pipeline, collection_response_from_documents,
+    collection_response_from_raw_documents_for_tests, member_route_for_tests,
+    project_listing_detail, project_listing_summaries, project_listing_summary,
+    resolve_listing_detail,
+};
+use chrono::{Duration, Utc};
+
+const README_API_V2_MARKERS: &[&str] = &[
+    "parallel read API under `/api/v2`",
+    "v1 stays available. v2 is additive and runs in parallel during migration.",
+    "Phase 1 exposes only `GET /api/v2/listings` and `GET /api/v2/listings/{id}`.",
+    "Listing resources are IDs-only for lookup-backed fields",
+    "Phase 1 has no `/api/v2/lookups/*` routes. Clients must resolve labels outside this API.",
+    "`/api/v2/listings/{id}` is an active-detail lookup alias for the current visible PF listing id. It is not a durable historical identity.",
+];
+
+const API_V2_DOC_MARKERS: &[&str] = &[
+    "# API v2, phase 1 contract",
+    "Phase 1 exposes only these routes:",
+    "`GET /api/v2/listings`",
+    "`GET /api/v2/listings/{id}`",
+    "`/api/v2/lookups/*` does not exist",
+    "v2 is IDs-only for lookup-backed references.",
+    "`player_name` and `description` stay inline text.",
+    "`/api/v2/listings/{id}` resolves the current active visible PF listing by listing id. It is an active-detail lookup alias, not a durable storage identity.",
+    "Missing, expired, or non-visible ids return `404 not_found`.",
+    "Avoid old label-based queries such as `world=` or `category=`.",
+    "Keep existing v1 integrations running while you add v2 support.",
+];
+
+const ACTIVE_FIXTURE_JSON: &str = r#"{
+  "id": 12345,
+  "content_id_lower": 456,
+  "name": "QWN0aXZl",
+  "description": "QWN0aXZlIGZpeHR1cmU=",
+  "created_world": 73,
+  "home_world": 73,
+  "current_world": 73,
+  "category": 64,
+  "last_server_restart": 1000,
+  "duty": 55,
+  "duty_type": 2,
+  "beginners_welcome": false,
+  "seconds_remaining": 1200,
+  "min_item_level": 0,
+  "num_parties": 1,
+  "slots_available": 8,
+  "objective": 3,
+  "conditions": 1,
+  "duty_finder_settings": 0,
+  "loot_rules": 0,
+  "search_area": 1,
+  "slots": [{ "accepting": 167772160 }],
+  "jobs_present": [5, 0, 0, 0, 0, 0, 0, 0]
+}"#;
+
+const DUPLICATE_OLD_FIXTURE_JSON: &str = r#"{
+  "id": 12345,
+  "content_id_lower": 457,
+  "name": "RHVwbGljYXRl",
+  "description": "T2xkIGR1cGxpY2F0ZSBmaXh0dXJl",
+  "created_world": 73,
+  "home_world": 73,
+  "current_world": 73,
+  "category": 64,
+  "last_server_restart": 999,
+  "duty": 55,
+  "duty_type": 2,
+  "beginners_welcome": false,
+  "seconds_remaining": 900,
+  "min_item_level": 0,
+  "num_parties": 1,
+  "slots_available": 8,
+  "objective": 3,
+  "conditions": 1,
+  "duty_finder_settings": 0,
+  "loot_rules": 0,
+  "search_area": 1,
+  "slots": [{ "accepting": 167772160 }],
+  "jobs_present": [5, 0, 0, 0, 0, 0, 0, 0]
+}"#;
+
+const CROSS_WORLD_FIXTURE_JSON: &str = r#"{
+  "id": 12346,
+  "content_id_lower": 458,
+  "name": "Q3Jvc3MgV29ybGQ=",
+  "description": "Q3Jvc3Mtd29ybGQgZml4dHVyZQ==",
+  "created_world": 73,
+  "home_world": 73,
+  "current_world": 73,
+  "category": 64,
+  "last_server_restart": 1000,
+  "duty": 55,
+  "duty_type": 2,
+  "beginners_welcome": false,
+  "seconds_remaining": 1200,
+  "min_item_level": 0,
+  "num_parties": 1,
+  "slots_available": 8,
+  "objective": 3,
+  "conditions": 1,
+  "duty_finder_settings": 0,
+  "loot_rules": 0,
+  "search_area": 1,
+  "slots": [{ "accepting": 167772160 }],
+  "jobs_present": [5, 0, 0, 0, 0, 0, 0, 0]
+}"#;
+
+const EXPIRED_FIXTURE_JSON: &str = r#"{
+  "id": 12345,
+  "content_id_lower": 459,
+  "name": "RXhwaXJlZA==",
+  "description": "RXhwaXJlZCBmaXh0dXJl",
+  "created_world": 73,
+  "home_world": 73,
+  "current_world": 73,
+  "category": 64,
+  "last_server_restart": 1000,
+  "duty": 55,
+  "duty_type": 2,
+  "beginners_welcome": false,
+  "seconds_remaining": 0,
+  "min_item_level": 0,
+  "num_parties": 1,
+  "slots_available": 8,
+  "objective": 3,
+  "conditions": 1,
+  "duty_finder_settings": 0,
+  "loot_rules": 0,
+  "search_area": 1,
+  "slots": [{ "accepting": 167772160 }],
+  "jobs_present": [5, 0, 0, 0, 0, 0, 0, 0]
+}"#;
+
+#[test]
+fn success_envelopes_are_consistent() {
+    let collection = CollectionEnvelope {
+        data: vec![sample_summary()],
+        pagination: Pagination {
+            total: 1,
+            page: 1,
+            per_page: 20,
+            total_pages: 1,
+        },
+    };
+
+    assert_eq!(
+        serde_json::to_value(&collection).unwrap(),
+        json!({
+            "data": [
+                {
+                    "id": 900001,
+                    "player_name": "Alice",
+                    "description": "Need clear",
+                    "created_world_id": 1167,
+                    "home_world_id": 1167,
+                    "category_id": 64,
+                    "duty_id": 1234,
+                    "duty_type_id": 0,
+                    "min_item_level": 710,
+                    "slots_filled": 6,
+                    "slots_available": 8,
+                    "time_left_seconds": 1200,
+                    "updated_at": "2026-04-23T12:34:56Z",
+                    "is_cross_world": true,
+                    "beginners_welcome": false
+                }
+            ],
+            "pagination": {
+                "total": 1,
+                "page": 1,
+                "per_page": 20,
+                "total_pages": 1
+            }
+        })
+    );
+
+    let member = ListingMemberResponse {
+        data: sample_detail(),
+    };
+
+    assert_eq!(
+        serde_json::to_value(&member).unwrap(),
+        json!({
+            "data": {
+                "id": 900001,
+                "player_name": "Alice",
+                "description": "Need clear",
+                "created_world_id": 1167,
+                "home_world_id": 1167,
+                "category_id": 64,
+                "duty_id": 1234,
+                "duty_type_id": 0,
+                "min_item_level": 710,
+                "slots_filled": 6,
+                "slots_available": 8,
+                "time_left_seconds": 1200,
+                "updated_at": "2026-04-23T12:34:56Z",
+                "is_cross_world": true,
+                "beginners_welcome": false,
+                "objective_ids": [1, 4],
+                "condition_ids": [2],
+                "loot_rule_id": 3,
+                "slots": [
+                    {
+                        "filled": true,
+                        "role_id": 3,
+                        "filled_job_id": 19,
+                        "accepted_job_ids": []
+                    },
+                    {
+                        "filled": false,
+                        "role_id": 2,
+                        "filled_job_id": null,
+                        "accepted_job_ids": [24, 28]
+                    }
+                ]
+            }
+        })
+    );
+}
+
+#[test]
+fn error_envelope_is_consistent() {
+    let error =
+        ErrorEnvelope::invalid_query("category_id", "category_id must be an unsigned integer");
+
+    assert_eq!(
+        serde_json::to_value(&error).unwrap(),
+        json!({
+            "error": {
+                "code": "invalid_query",
+                "message": "category_id must be an unsigned integer",
+                "details": {
+                    "field": "category_id"
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn docs_examples_match_contract() {
+    let readme = include_str!("../../README.md");
+    let api_v2_doc = include_str!("../../docs/api-v2.md");
+    let normalized_api_v2_doc = strip_whitespace(api_v2_doc);
+
+    for marker in README_API_V2_MARKERS {
+        assert!(readme.contains(marker), "README.md missing marker: {marker}");
+    }
+
+    for marker in API_V2_DOC_MARKERS {
+        assert!(
+            api_v2_doc.contains(marker),
+            "docs/api-v2.md missing marker: {marker}"
+        );
+    }
+
+    let collection = CollectionEnvelope {
+        data: vec![sample_summary()],
+        pagination: Pagination {
+            total: 1,
+            page: 1,
+            per_page: 20,
+            total_pages: 1,
+        },
+    };
+    let detail = ListingMemberResponse {
+        data: sample_detail(),
+    };
+
+    let collection_json = serde_json::to_string_pretty(&collection).unwrap();
+    let detail_json = serde_json::to_string_pretty(&detail).unwrap();
+
+    assert!(
+        normalized_api_v2_doc.contains(&strip_whitespace(&collection_json)),
+        "docs/api-v2.md collection example drifted from contract"
+    );
+    assert!(
+        normalized_api_v2_doc.contains(&strip_whitespace(&detail_json)),
+        "docs/api-v2.md detail example drifted from contract"
+    );
+
+    for stale in [
+        "GET /api/v2/lookups",
+        "GET /api/v2/lookups/worlds",
+        "GET /api/v2/lookups/duties",
+        "GET /api/v2/lookups/jobs",
+        "GET /api/v2/lookups/categories",
+    ] {
+        assert!(
+            !api_v2_doc.contains(stale),
+            "docs/api-v2.md must not document nonexistent lookup route {stale}"
+        );
+    }
+}
+
+fn strip_whitespace(value: &str) -> String {
+    value.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+#[test]
+fn id_inventory_is_stable() {
+    assert_eq!(id_inventory::world_ids().len(), 131);
+    assert_eq!(id_inventory::world_ids(), {
+        let mut ids = crate::ffxiv::WORLDS.keys().copied().collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids
+    });
+    assert_eq!(id_inventory::world_id(1167), 1167);
+
+    assert_eq!(
+        id_inventory::CATEGORY_IDS,
+        [0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+    );
+    assert_eq!(id_inventory::category_id(DutyCategory::HighEndDuty), 64);
+    assert_eq!(id_inventory::duty_id(1234), 1234);
+
+    assert_eq!(id_inventory::DUTY_TYPE_IDS, [0, 1, 2]);
+    assert_eq!(id_inventory::duty_type_id(DutyType::Other), 0);
+    assert_eq!(id_inventory::duty_type_id(DutyType::Roulette), 1);
+    assert_eq!(id_inventory::duty_type_id(DutyType::Normal), 2);
+
+    assert_eq!(
+        id_inventory::job_ids(),
+        vec![
+            1, 2, 3, 4, 5, 6, 7, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+            35, 36, 37, 38, 39, 40, 41, 42,
+        ]
+    );
+    assert_eq!(id_inventory::filled_job_id(19), Some(19));
+    assert_eq!(id_inventory::filled_job_id(8), Some(8));
+    assert_eq!(
+        id_inventory::accepted_job_ids(JobFlags::WHITE_MAGE | JobFlags::SCHOLAR),
+        vec![24, 28]
+    );
+
+    assert_eq!(id_inventory::ROLE_IDS, [1, 2, 3]);
+    assert_eq!(id_inventory::role_id(ffxiv_types_cn::Role::Dps), 1);
+    assert_eq!(id_inventory::role_id(ffxiv_types_cn::Role::Healer), 2);
+    assert_eq!(id_inventory::role_id(ffxiv_types_cn::Role::Tank), 3);
+    assert_eq!(id_inventory::role_id_for_job_id(19), Some(3));
+    assert_eq!(id_inventory::role_id_for_job_id(24), Some(2));
+    assert_eq!(id_inventory::role_id_for_job_ids(&[24, 28]), Some(2));
+    assert_eq!(id_inventory::role_id_for_job_ids(&[19, 24]), None);
+
+    assert_eq!(id_inventory::OBJECTIVE_IDS, [1, 2, 4]);
+    assert_eq!(
+        id_inventory::objective_ids(
+            ObjectiveFlags::DUTY_COMPLETION | ObjectiveFlags::PRACTICE | ObjectiveFlags::LOOT,
+        ),
+        vec![1, 2, 4]
+    );
+    assert_eq!(
+        id_inventory::objective_ids(ObjectiveFlags::NONE),
+        Vec::<u32>::new()
+    );
+
+    assert_eq!(id_inventory::CONDITION_IDS, [2, 4, 8]);
+    assert_eq!(
+        id_inventory::condition_ids(ConditionFlags::NONE),
+        Vec::<u32>::new()
+    );
+    assert_eq!(
+        id_inventory::condition_ids(
+            ConditionFlags::DUTY_COMPLETE | ConditionFlags::DUTY_COMPLETE_WEEKLY_REWARD_UNCLAIMED,
+        ),
+        vec![2, 8]
+    );
+
+    assert_eq!(id_inventory::LOOT_RULE_IDS, [0, 1, 2, 3]);
+    assert_eq!(id_inventory::loot_rule_id(LootRuleFlags::NONE), 0);
+    assert_eq!(
+        id_inventory::loot_rule_id(LootRuleFlags::GREED_ONLY | LootRuleFlags::LOOTMASTER),
+        3
+    );
+}
+
+#[test]
+fn datacenter_not_exposed_in_primary_resources() {
+    assert!(!id_inventory::PHASE_ONE_PRIMARY_EXPOSES_DATACENTER);
+
+    for payload in [
+        serde_json::to_value(sample_summary()).unwrap(),
+        serde_json::to_value(sample_detail()).unwrap(),
+    ] {
+        let object = payload.as_object().unwrap();
+        assert!(!object.contains_key("datacenter"));
+        assert!(!object.contains_key("datacenter_id"));
+    }
+}
+
+#[tokio::test]
+async fn malformed_filters_return_400() {
+    let cases = [
+        (
+            "/api/v2/listings?category_id=abc",
+            ErrorEnvelope::invalid_query("category_id", "category_id must be an unsigned integer"),
+        ),
+        (
+            "/api/v2/listings?job_ids=1,tank",
+            ErrorEnvelope::invalid_query(
+                "job_ids",
+                "job_ids must be a comma-separated list of unsigned integers",
+            ),
+        ),
+        (
+            "/api/v2/listings?per_page=101",
+            ErrorEnvelope::invalid_query("per_page", "per_page must be between 1 and 100"),
+        ),
+        (
+            "/api/v2/listings?unknown=1",
+            ErrorEnvelope::invalid_query("unknown", "unknown is not a supported query parameter"),
+        ),
+    ];
+
+    for (path, expected_error) in cases {
+        let response = warp::test::request()
+            .method("GET")
+            .path(path)
+            .reply(&crate::web::v2::listings::collection_route_for_tests())
+            .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "path: {path}");
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(response.body()).unwrap(),
+            serde_json::to_value(expected_error).unwrap(),
+            "path: {path}",
+        );
+    }
+}
+
+#[tokio::test]
+async fn legacy_label_filters_are_rejected() {
+    let cases = [
+        (
+            "/api/v2/listings?world=%E7%8C%AB%E5%B0%8F%E8%83%96",
+            ErrorEnvelope::invalid_query(
+                "world",
+                "world is not supported in v2; use created_world_id or home_world_id",
+            ),
+        ),
+        (
+            "/api/v2/listings?category=HighEndDuty",
+            ErrorEnvelope::invalid_query(
+                "category",
+                "category is not supported in v2; use category_id",
+            ),
+        ),
+    ];
+
+    for (path, expected_error) in cases {
+        let response = warp::test::request()
+            .method("GET")
+            .path(path)
+            .reply(&crate::web::v2::listings::collection_route_for_tests())
+            .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "path: {path}");
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(response.body()).unwrap(),
+            serde_json::to_value(expected_error).unwrap(),
+            "path: {path}",
+        );
+    }
+}
+
+// =============================================================================
+// Lookup-Route Absence Contract Tests
+// =============================================================================
+//
+// Verifies that phase-1 v2 does NOT expose any lookup endpoints. This is a frozen
+// design decision (no phase-1 lookup endpoints).
+//
+// Tests:
+// - no_lookup_routes_exposed_in_phase1: compile-time assertion that lookups are not mounted
+// - unmounted_lookup_routes_return_not_found: runtime tests that /api/v2/lookups/* returns 404
+
+#[test]
+fn no_lookup_routes_exposed_in_phase1() {
+    // PHASE_ONE_LOOKUPS_EXPOSED must be explicitly false
+    use crate::web::v2::lookups::PHASE_ONE_LOOKUPS_EXPOSED;
+    assert!(
+        !PHASE_ONE_LOOKUPS_EXPOSED,
+        "PHASE_ONE_LOOKUPS_EXPOSED must be false in phase-1"
+    );
+}
+
+#[tokio::test]
+async fn unmounted_lookup_routes_return_not_found() {
+    let lookup_paths = [
+        "/api/v2/lookups",
+        "/api/v2/lookups/",
+        "/api/v2/lookups/worlds",
+        "/api/v2/lookups/worlds/1167",
+        "/api/v2/lookups/duties",
+        "/api/v2/lookups/duties/55",
+        "/api/v2/lookups/jobs",
+        "/api/v2/lookups/categories",
+    ];
+
+    for path in lookup_paths {
+        let response = warp::test::request()
+            .method("GET")
+            .path(path)
+            .reply(&crate::web::v2::listings::collection_route_for_tests())
+            .await;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "path {path} should return 404 NOT_FOUND"
+        );
+    }
+}
+
+fn sample_summary() -> ListingSummary {
+    ListingSummary {
+        id: 900001,
+        player_name: "Alice".into(),
+        description: "Need clear".into(),
+        created_world_id: 1167,
+        home_world_id: 1167,
+        category_id: 64,
+        duty_id: 1234,
+        duty_type_id: 0,
+        min_item_level: 710,
+        slots_filled: 6,
+        slots_available: 8,
+        time_left_seconds: 1200,
+        updated_at: "2026-04-23T12:34:56Z".into(),
+        is_cross_world: true,
+        beginners_welcome: false,
+    }
+}
+
+fn sample_detail() -> ListingDetail {
+    ListingDetail {
+        id: 900001,
+        player_name: "Alice".into(),
+        description: "Need clear".into(),
+        created_world_id: 1167,
+        home_world_id: 1167,
+        category_id: 64,
+        duty_id: 1234,
+        duty_type_id: 0,
+        min_item_level: 710,
+        slots_filled: 6,
+        slots_available: 8,
+        time_left_seconds: 1200,
+        updated_at: "2026-04-23T12:34:56Z".into(),
+        is_cross_world: true,
+        beginners_welcome: false,
+        objective_ids: vec![1, 4],
+        condition_ids: vec![2],
+        loot_rule_id: 3,
+        slots: vec![
+            ListingSlot {
+                filled: true,
+                role_id: 3,
+                filled_job_id: Some(19),
+                accepted_job_ids: vec![],
+            },
+            ListingSlot {
+                filled: false,
+                role_id: 2,
+                filled_job_id: None,
+                accepted_job_ids: vec![24, 28],
+            },
+        ],
+    }
+}
+
+#[tokio::test]
+async fn duplicate_listing_id_returns_latest_active_detail() {
+    let now = Utc::now();
+    let active = queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(2), 1200.0);
+    let duplicate_old = queried_fixture(
+        DUPLICATE_OLD_FIXTURE_JSON,
+        now - Duration::seconds(30),
+        900.0,
+    );
+    let expired = queried_fixture(EXPIRED_FIXTURE_JSON, now - Duration::minutes(1), -1.0);
+    let expected_updated_at = duplicate_old.updated_at.to_rfc3339();
+
+    let response = warp::test::request()
+        .method("GET")
+        .path("/api/v2/listings/12345")
+        .reply(&member_route_for_tests(vec![expired, duplicate_old, active]))
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = serde_json::from_slice::<serde_json::Value>(response.body()).unwrap();
+    assert_eq!(body["data"]["id"], json!(12345));
+    assert_eq!(body["data"]["player_name"], json!("Duplicate"));
+    assert_eq!(body["data"]["time_left_seconds"], json!(900));
+    assert_eq!(body["data"]["updated_at"], json!(expected_updated_at));
+}
+
+#[test]
+fn expired_fixture_has_zero_time() {
+    let expired: crate::listing::PartyFinderListing =
+        serde_json::from_str(EXPIRED_FIXTURE_JSON).expect("expired fixture must parse");
+
+    assert_eq!(expired.id, 12345);
+    assert_eq!(
+        expired.seconds_remaining, 0,
+        "expired fixture must have 0 remaining time"
+    );
+    assert_eq!(
+        expired.last_server_restart, 1000,
+        "expired shares restart with active fixture"
+    );
+}
+
+#[test]
+fn all_fixtures_are_public() {
+    // All fixtures use search_area=1 (DATA_CENTRE bit only) — not bit 2 (private)
+    use crate::listing::PartyFinderListing;
+    use crate::listing::SearchAreaFlags;
+
+    let active: PartyFinderListing =
+        serde_json::from_str(ACTIVE_FIXTURE_JSON).expect("active fixture must parse");
+    let expired: PartyFinderListing =
+        serde_json::from_str(EXPIRED_FIXTURE_JSON).expect("expired fixture must parse");
+    let duplicate_old: PartyFinderListing =
+        serde_json::from_str(DUPLICATE_OLD_FIXTURE_JSON).expect("duplicate_old fixture must parse");
+    let cross_world: PartyFinderListing =
+        serde_json::from_str(CROSS_WORLD_FIXTURE_JSON).expect("cross_world fixture must parse");
+
+    assert!(
+        !active.search_area.contains(SearchAreaFlags::PRIVATE),
+        "active fixture must be public"
+    );
+    assert!(
+        !expired.search_area.contains(SearchAreaFlags::PRIVATE),
+        "expired fixture must be public"
+    );
+    assert!(
+        !duplicate_old.search_area.contains(SearchAreaFlags::PRIVATE),
+        "duplicate_old fixture must be public"
+    );
+    assert!(
+        !cross_world.search_area.contains(SearchAreaFlags::PRIVATE),
+        "cross_world fixture must be public"
+    );
+}
+
+#[test]
+fn listings_projection_excludes_labels() {
+    let now = Utc::now();
+    let active = queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(1), 1200.9);
+    let summary = project_listing_summary(&active).expect("active listing should project");
+    let detail = project_listing_detail(&active).expect("active detail should project");
+
+    assert_eq!(
+        summary,
+        ListingSummary {
+            id: 12345,
+            player_name: "Active".into(),
+            description: "Active fixture".into(),
+            created_world_id: 73,
+            home_world_id: 73,
+            category_id: 64,
+            duty_id: 55,
+            duty_type_id: 2,
+            min_item_level: 0,
+            slots_filled: 1,
+            slots_available: 8,
+            time_left_seconds: 1200,
+            updated_at: active.updated_at.to_rfc3339(),
+            is_cross_world: true,
+            beginners_welcome: false,
+        }
+    );
+
+    assert_eq!(
+        detail,
+        ListingDetail {
+            id: 12345,
+            player_name: "Active".into(),
+            description: "Active fixture".into(),
+            created_world_id: 73,
+            home_world_id: 73,
+            category_id: 64,
+            duty_id: 55,
+            duty_type_id: 2,
+            min_item_level: 0,
+            slots_filled: 1,
+            slots_available: 8,
+            time_left_seconds: 1200,
+            updated_at: active.updated_at.to_rfc3339(),
+            is_cross_world: true,
+            beginners_welcome: false,
+            objective_ids: vec![1, 2],
+            condition_ids: vec![],
+            loot_rule_id: 0,
+            slots: vec![ListingSlot {
+                filled: true,
+                role_id: 1,
+                filled_job_id: Some(5),
+                accepted_job_ids: vec![],
+            }],
+        }
+    );
+
+    for payload in [
+        serde_json::to_value(&summary).unwrap(),
+        serde_json::to_value(&detail).unwrap(),
+    ] {
+        let object = payload
+            .as_object()
+            .expect("listing projections serialize as objects");
+        for forbidden in [
+            "name",
+            "created_world",
+            "home_world",
+            "category",
+            "duty",
+            "duty_type",
+            "datacenter",
+        ] {
+            assert!(
+                !object.contains_key(forbidden),
+                "projection unexpectedly exposed label field {forbidden}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn listing_detail_is_ids_only() {
+    let now = Utc::now();
+    let active = queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(1), 1200.9);
+
+    let response = warp::test::request()
+        .method("GET")
+        .path("/api/v2/listings/12345")
+        .reply(&member_route_for_tests(vec![active]))
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = serde_json::from_slice::<serde_json::Value>(response.body()).unwrap();
+    let object = body["data"].as_object().cloned().unwrap();
+
+    for required in [
+        "id",
+        "player_name",
+        "description",
+        "created_world_id",
+        "home_world_id",
+        "category_id",
+        "duty_id",
+        "duty_type_id",
+        "min_item_level",
+        "slots_filled",
+        "slots_available",
+        "time_left_seconds",
+        "updated_at",
+        "is_cross_world",
+        "beginners_welcome",
+        "objective_ids",
+        "condition_ids",
+        "loot_rule_id",
+        "slots",
+    ] {
+        assert!(object.contains_key(required), "missing {required}");
+    }
+
+    for forbidden in [
+        "name",
+        "created_world",
+        "home_world",
+        "category",
+        "duty",
+        "duty_type",
+        "objective",
+        "conditions",
+        "loot_rules",
+        "datacenter",
+        "role",
+        "job",
+        "job_id",
+    ] {
+        assert!(
+            !object.contains_key(forbidden),
+            "detail unexpectedly exposed {forbidden}"
+        );
+    }
+
+    assert_eq!(body["data"]["objective_ids"], json!([1, 2]));
+    assert_eq!(body["data"]["condition_ids"], json!([]));
+    assert_eq!(body["data"]["loot_rule_id"], json!(0));
+    assert_eq!(
+        body["data"]["slots"],
+        json!([
+            {
+                "filled": true,
+                "role_id": 1,
+                "filled_job_id": 5,
+                "accepted_job_ids": [],
+            }
+        ])
+    );
+}
+
+#[test]
+fn listings_summary_is_ids_only() {
+    let now = Utc::now();
+    let active = queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(1), 1200.0);
+    let cross_world = queried_fixture(CROSS_WORLD_FIXTURE_JSON, now - Duration::minutes(2), 900.0);
+    let response = collection_response_from_documents(
+        ListingsQuery {
+            page: 1,
+            per_page: 20,
+            search: Some("fixture".into()),
+            ..Default::default()
+        },
+        [&active, &cross_world],
+    );
+
+    assert_eq!(response.pagination.total, 2);
+    assert_eq!(response.pagination.page, 1);
+    assert_eq!(response.pagination.per_page, 20);
+    assert_eq!(response.pagination.total_pages, 1);
+    assert_eq!(response.data.len(), 2);
+
+    for summary in &response.data {
+        let object = serde_json::to_value(summary)
+            .unwrap()
+            .as_object()
+            .cloned()
+            .unwrap();
+
+        for required in [
+            "id",
+            "player_name",
+            "description",
+            "created_world_id",
+            "home_world_id",
+            "category_id",
+            "duty_id",
+            "duty_type_id",
+            "min_item_level",
+            "slots_filled",
+            "slots_available",
+            "time_left_seconds",
+            "updated_at",
+            "is_cross_world",
+            "beginners_welcome",
+        ] {
+            assert!(object.contains_key(required), "missing {required}");
+        }
+
+        for forbidden in [
+            "name",
+            "created_world",
+            "home_world",
+            "category",
+            "duty",
+            "duty_type",
+            "datacenter",
+            "datacenter_id",
+            "objective_ids",
+            "condition_ids",
+            "loot_rule_id",
+            "slots",
+        ] {
+            assert!(
+                !object.contains_key(forbidden),
+                "summary unexpectedly exposed {forbidden}"
+            );
+        }
+    }
+
+    assert_eq!(response.data[0].player_name, "Active");
+    assert_eq!(response.data[0].description, "Active fixture");
+    assert_eq!(response.data[1].player_name, "Cross World");
+    assert_eq!(response.data[1].description, "Cross-world fixture");
+}
+
+#[test]
+fn collection_pipeline_uses_job_flag_bits_for_public_job_ids() {
+    let pipeline = collection_pipeline(&ListingsQuery {
+        job_ids: vec![24],
+        ..Default::default()
+    });
+
+    let job_match = pipeline
+        .iter()
+        .find(|stage| stage.get_document("$match").ok().and_then(|stage| stage.get_array("$or").ok()).is_some())
+        .expect("job filter stage should exist");
+    let job_conditions = job_match
+        .get_document("$match")
+        .unwrap()
+        .get_array("$or")
+        .unwrap();
+    let bits = job_conditions[0]
+        .as_document()
+        .unwrap()
+        .get_document("listing.slots")
+        .unwrap()
+        .get_document("$elemMatch")
+        .unwrap()
+        .get_document("accepting")
+        .unwrap()
+        .get_i64("$bitsAllSet")
+        .unwrap();
+
+    assert_eq!(bits, JobFlags::WHITE_MAGE.bits() as i64);
+}
+
+#[test]
+fn collection_response_filters_public_job_ids_by_inventory_mapping() {
+    let now = Utc::now();
+    let mut white_mage = queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(1), 1200.0);
+    white_mage.listing.slots[0].accepting = JobFlags::WHITE_MAGE;
+
+    let mut red_mage = queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(1), 1200.0);
+    red_mage.listing.id = 54321;
+    red_mage.listing.slots[0].accepting = JobFlags::RED_MAGE;
+
+    let response = collection_response_from_documents(
+        ListingsQuery {
+            job_ids: vec![24],
+            ..Default::default()
+        },
+        [&white_mage, &red_mage],
+    );
+
+    assert_eq!(response.pagination.total, 1);
+    assert_eq!(response.data.len(), 1);
+    assert_eq!(response.data[0].id, 12345);
+}
+
+#[tokio::test]
+async fn collection_decode_failure_returns_internal_error() {
+    let response = collection_response_from_raw_documents_for_tests(
+        ListingsQuery::default(),
+        vec![doc! {
+            "listing": { "id": 12345 },
+            "updated_at": chrono::Utc::now(),
+        }],
+    );
+    let status = response.status();
+    let body = warp::hyper::body::to_bytes(response.into_body()).await.unwrap();
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
+        json!({
+            "error": {
+                "code": "internal_error",
+                "message": "Failed to load API v2 listings",
+                "details": {}
+            }
+        })
+    );
+}
+
+#[tokio::test]
+async fn well_formed_unknown_filters_return_empty_collection() {
+    let cases = [
+        "/api/v2/listings?created_world_id=999999",
+        "/api/v2/listings?home_world_id=999999",
+        "/api/v2/listings?category_id=999999",
+        "/api/v2/listings?duty_id=999999",
+        "/api/v2/listings?job_ids=999999",
+        "/api/v2/listings?search=fixture&created_world_id=999999",
+    ];
+
+    for path in cases {
+        let response = warp::test::request()
+            .method("GET")
+            .path(path)
+            .reply(&crate::web::v2::listings::collection_route_for_tests())
+            .await;
+
+        assert_eq!(response.status(), StatusCode::OK, "path: {path}");
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(response.body()).unwrap(),
+            json!({
+                "data": [],
+                "pagination": {
+                    "total": 0,
+                    "page": 1,
+                    "per_page": 20,
+                    "total_pages": 0,
+                }
+            }),
+            "path: {path}",
+        );
+    }
+}
+
+#[test]
+fn expired_listings_are_excluded_from_v2() {
+    let now = Utc::now();
+    let active = queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(1), 1200.0);
+    let expired = queried_fixture(EXPIRED_FIXTURE_JSON, now - Duration::minutes(1), -1.0);
+
+    assert!(project_listing_summary(&expired).is_none());
+    assert_eq!(
+        project_listing_summaries([&expired]),
+        Vec::<ListingSummary>::new()
+    );
+    assert_eq!(
+        project_listing_summaries([&expired, &active]),
+        vec![project_listing_summary(&active).unwrap()]
+    );
+    assert!(resolve_listing_detail(12345, [&expired]).is_none());
+}
+
+#[test]
+fn detail_projection_prefers_latest_active_duplicate_id() {
+    let now = Utc::now();
+    let active = queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(2), 1200.0);
+    let duplicate_old = queried_fixture(
+        DUPLICATE_OLD_FIXTURE_JSON,
+        now - Duration::seconds(30),
+        900.0,
+    );
+    let expired = queried_fixture(EXPIRED_FIXTURE_JSON, now - Duration::minutes(1), -1.0);
+
+    let detail = resolve_listing_detail(12345, [&expired, &duplicate_old, &active])
+        .expect("latest active duplicate should resolve");
+
+    assert_eq!(detail.player_name, "Duplicate");
+    assert_eq!(detail.time_left_seconds, 900);
+    assert_eq!(detail.updated_at, duplicate_old.updated_at.to_rfc3339());
+}
+
+#[tokio::test]
+async fn expired_or_missing_listing_returns_404() {
+    let now = Utc::now();
+    let expired = queried_fixture(EXPIRED_FIXTURE_JSON, now - Duration::minutes(1), -1.0);
+    let active = queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(1), 1200.0);
+    let private = private_queried_fixture(ACTIVE_FIXTURE_JSON, now - Duration::minutes(1), 1200.0);
+
+    let expired_response = warp::test::request()
+        .method("GET")
+        .path("/api/v2/listings/12345")
+        .reply(&member_route_for_tests(vec![expired]))
+        .await;
+    assert_eq!(expired_response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(expired_response.body()).unwrap(),
+        json!({
+            "error": {
+                "code": "not_found",
+                "message": "Listing not found",
+                "details": {
+                    "id": 12345,
+                }
+            }
+        })
+    );
+
+    let missing_response = warp::test::request()
+        .method("GET")
+        .path("/api/v2/listings/99999")
+        .reply(&member_route_for_tests(vec![active]))
+        .await;
+    assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(missing_response.body()).unwrap(),
+        json!({
+            "error": {
+                "code": "not_found",
+                "message": "Listing not found",
+                "details": {
+                    "id": 99999,
+                }
+            }
+        })
+    );
+
+    let private_response = warp::test::request()
+        .method("GET")
+        .path("/api/v2/listings/12345")
+        .reply(&member_route_for_tests(vec![private]))
+        .await;
+    assert_eq!(private_response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(private_response.body()).unwrap(),
+        json!({
+            "error": {
+                "code": "not_found",
+                "message": "Listing not found",
+                "details": {
+                    "id": 12345,
+                }
+            }
+        })
+    );
+}
+
+fn queried_fixture(
+    fixture_json: &str,
+    updated_at: chrono::DateTime<Utc>,
+    time_left: f64,
+) -> QueriedListing {
+    let listing = serde_json::from_str(fixture_json).expect("fixture must parse");
+
+    QueriedListing {
+        created_at: updated_at - Duration::minutes(1),
+        updated_at,
+        updated_minute: updated_at,
+        time_left,
+        listing,
+    }
+}
+
+fn private_queried_fixture(
+    fixture_json: &str,
+    updated_at: chrono::DateTime<Utc>,
+    time_left: f64,
+) -> QueriedListing {
+    let mut fixture = queried_fixture(fixture_json, updated_at, time_left);
+    fixture.listing.search_area = crate::listing::SearchAreaFlags::PRIVATE;
+    fixture
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -21,6 +21,9 @@ mod ffxiv;
 #[cfg(test)]
 mod test;
 
+#[cfg(test)]
+mod api_v2_contract;
+
 #[tokio::main]
 async fn main() {
     let mut args: Vec<String> = std::env::args().skip(1).collect();

--- a/server/src/test.rs
+++ b/server/src/test.rs
@@ -1,4 +1,7 @@
-use crate::listing::{PartyFinderListing, DutyType, ObjectiveFlags, ConditionFlags, DutyFinderSettingsFlags, LootRuleFlags, SearchAreaFlags, DutyCategory, PartyFinderSlot, JobFlags};
+use crate::listing::{
+    ConditionFlags, DutyCategory, DutyFinderSettingsFlags, DutyType, JobFlags, LootRuleFlags,
+    ObjectiveFlags, PartyFinderListing, PartyFinderSlot, SearchAreaFlags,
+};
 use sestring::SeString;
 
 const LISTING: &str = r###"
@@ -11,7 +14,6 @@ const LISTING: &str = r###"
   "home_world": 73,
   "current_world": 73,
   "category": 0,
-  "last_server_restart": 1234567890,
   "duty": 55,
   "duty_type": 2,
   "beginners_welcome": false,
@@ -19,6 +21,7 @@ const LISTING: &str = r###"
   "min_item_level": 0,
   "num_parties": 1,
   "slots_available": 7,
+  "last_server_restart": 1234567890,
   "objective": 3,
   "conditions": 1,
   "duty_finder_settings": 0,
@@ -76,10 +79,7 @@ lazy_static::lazy_static! {
 #[test]
 fn deserialise_listing() {
     let listing: PartyFinderListing = serde_json::from_str(LISTING).unwrap();
-    assert_eq!(
-        listing,
-        *EXPECTED,
-    )
+    assert_eq!(listing, *EXPECTED,)
 }
 
 #[test]
@@ -88,4 +88,128 @@ fn serialise_listing() {
         serde_json::to_string_pretty(&*EXPECTED).unwrap(),
         LISTING.trim(),
     );
+}
+
+mod api_v1_regression {
+    use super::*;
+
+    #[test]
+    fn listings_shape_unchanged() {
+        const V1_COLLECTION_JSON: &str = r###"{
+  "data": [
+    {
+      "id": 123,
+      "name": "Test Player",
+      "description": "Test description",
+      "created_world": "Cerberus",
+      "created_world_id": 73,
+      "home_world": "Cerberus",
+      "home_world_id": 73,
+      "category": "Dungeons",
+      "category_id": 1,
+      "duty": "The Navel",
+      "min_item_level": 0,
+      "slots_filled": 1,
+      "slots_available": 7,
+      "time_left": 3000.5,
+      "updated_at": "2024-01-01T00:00:00Z",
+      "is_cross_world": true,
+      "datacenter": "Gaia"
+    }
+  ],
+  "pagination": {
+    "total": 1,
+    "page": 1,
+    "per_page": 20,
+    "total_pages": 1
+  }
+}"###;
+
+        let value: serde_json::Value =
+            serde_json::from_str(V1_COLLECTION_JSON).expect("must parse");
+
+        assert!(value.get("data").is_some(), "must have data field");
+        assert!(
+            value.get("pagination").is_some(),
+            "must have pagination field"
+        );
+
+        let pagination = value.get("pagination").unwrap().as_object().unwrap();
+        assert!(pagination.contains_key("total"));
+        assert!(pagination.contains_key("page"));
+        assert!(pagination.contains_key("per_page"));
+        assert!(pagination.contains_key("total_pages"));
+
+        let listing = value["data"].as_array().unwrap().first().unwrap();
+        assert!(listing.get("id").is_some());
+        assert!(listing.get("name").is_some());
+        assert!(listing.get("created_world").is_some());
+        assert!(listing.get("category").is_some());
+        assert!(listing.get("duty").is_some());
+    }
+
+    #[test]
+    fn listing_detail_shape_unchanged() {
+        const V1_DETAIL_JSON: &str = r###"{
+  "id": 123,
+  "name": "Test Player",
+  "description": "Test description",
+  "created_world": "Cerberus",
+  "home_world": "Cerberus",
+  "category": "Dungeons",
+  "duty": "The Navel",
+  "min_item_level": 0,
+  "slots_filled": 1,
+  "slots_available": 7,
+  "time_left": 3000.5,
+  "updated_at": "2024-01-01T00:00:00Z",
+  "is_cross_world": true,
+  "beginners_welcome": false,
+  "duty_type": "Normal",
+  "objective": "Boss",
+  "conditions": "None",
+  "loot_rules": "Normal",
+  "slots": [
+    {
+      "filled": true,
+      "role": "DPS",
+      "role_id": 3,
+      "job": "Ninja",
+      "job_id": [34]
+    }
+  ],
+  "datacenter": "Gaia"
+}"###;
+
+        let value: serde_json::Value = serde_json::from_str(V1_DETAIL_JSON).expect("must parse");
+
+        assert_eq!(value.get("id").unwrap().as_u64().unwrap(), 123);
+        assert!(value.get("name").is_some());
+        assert!(value.get("created_world").is_some());
+        assert!(value.get("home_world").is_some());
+        assert!(value.get("category").is_some());
+        assert!(value.get("duty").is_some());
+        assert!(value.get("slots_available").is_some());
+        assert!(value.get("slots").is_some());
+
+        assert!(value.get("beginners_welcome").is_some());
+        assert!(value.get("duty_type").is_some());
+        assert!(value.get("objective").is_some());
+        assert!(value.get("conditions").is_some());
+        assert!(value.get("loot_rules").is_some());
+    }
+
+    #[test]
+    fn contribute_multiple_shape_unchanged() {
+        let payload = format!("[{}]", LISTING.trim());
+        let listings: Vec<PartyFinderListing> = serde_json::from_str(&payload).expect("must parse");
+
+        assert_eq!(listings.len(), 1);
+        assert_eq!(listings.first().unwrap(), &*EXPECTED);
+
+        let actual = serde_json::to_value(&listings).expect("must serialize");
+        let expected: serde_json::Value =
+            serde_json::from_str(&payload).expect("payload fixture must parse");
+        assert_eq!(actual, expected);
+    }
 }

--- a/server/src/web.rs
+++ b/server/src/web.rs
@@ -38,6 +38,7 @@ use crate::{
 
 mod stats;
 pub mod api;
+pub mod v2;
 
 use crate::web::api::{ApiResponse, DetailedApiListing, ApiListing};
 
@@ -297,6 +298,7 @@ fn router(state: Arc<State>) -> BoxedFilter<(impl Reply, )> {
         .or(contribute_multiple(Arc::clone(&state)))
         .or(crate::web::api::listings_api(Arc::clone(&state)))
         .or(crate::web::api::listing_detail_api(Arc::clone(&state)))
+        .or(crate::web::v2::routes(Arc::clone(&state)))
         .or(index())
         .boxed()
 }

--- a/server/src/web/v2/contracts.rs
+++ b/server/src/web/v2/contracts.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Pagination {
+    pub total: usize,
+    pub page: usize,
+    pub per_page: usize,
+    pub total_pages: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CollectionEnvelope<T> {
+    pub data: Vec<T>,
+    pub pagination: Pagination,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemberEnvelope<T> {
+    pub data: T,
+}
+
+pub type ListingCollectionResponse = CollectionEnvelope<ListingSummary>;
+pub type ListingMemberResponse = MemberEnvelope<ListingDetail>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ErrorEnvelope {
+    pub error: ErrorBody,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ErrorBody {
+    pub code: String,
+    pub message: String,
+    pub details: Map<String, Value>,
+}
+
+impl ErrorEnvelope {
+    pub fn new(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        details: Map<String, Value>,
+    ) -> Self {
+        Self {
+            error: ErrorBody {
+                code: code.into(),
+                message: message.into(),
+                details,
+            },
+        }
+    }
+
+    pub fn invalid_query(field: impl Into<String>, message: impl Into<String>) -> Self {
+        let field = field.into();
+        let message = message.into();
+        let mut details = Map::new();
+        details.insert("field".into(), Value::String(field));
+
+        Self::new("invalid_query", message, details)
+    }
+
+    pub fn not_implemented(message: impl Into<String>) -> Self {
+        Self::new("not_implemented", message, Map::new())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListingSummary {
+    pub id: u32,
+    pub player_name: String,
+    pub description: String,
+    pub created_world_id: u32,
+    pub home_world_id: u32,
+    pub category_id: u32,
+    pub duty_id: u32,
+    pub duty_type_id: u32,
+    pub min_item_level: u16,
+    pub slots_filled: usize,
+    pub slots_available: u8,
+    pub time_left_seconds: u32,
+    pub updated_at: String,
+    pub is_cross_world: bool,
+    pub beginners_welcome: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListingDetail {
+    pub id: u32,
+    pub player_name: String,
+    pub description: String,
+    pub created_world_id: u32,
+    pub home_world_id: u32,
+    pub category_id: u32,
+    pub duty_id: u32,
+    pub duty_type_id: u32,
+    pub min_item_level: u16,
+    pub slots_filled: usize,
+    pub slots_available: u8,
+    pub time_left_seconds: u32,
+    pub updated_at: String,
+    pub is_cross_world: bool,
+    pub beginners_welcome: bool,
+    pub objective_ids: Vec<u32>,
+    pub condition_ids: Vec<u32>,
+    pub loot_rule_id: u32,
+    pub slots: Vec<ListingSlot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListingSlot {
+    pub filled: bool,
+    pub role_id: u32,
+    pub filled_job_id: Option<u32>,
+    pub accepted_job_ids: Vec<u32>,
+}

--- a/server/src/web/v2/filters.rs
+++ b/server/src/web/v2/filters.rs
@@ -1,0 +1,190 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::contracts::ErrorEnvelope;
+
+pub const DEFAULT_PAGE: usize = 1;
+pub const DEFAULT_PER_PAGE: usize = 20;
+pub const MAX_PER_PAGE: usize = 100;
+
+const SUPPORTED_QUERY_FIELDS: &[&str] = &[
+    "page",
+    "per_page",
+    "created_world_id",
+    "home_world_id",
+    "category_id",
+    "duty_id",
+    "job_ids",
+    "search",
+];
+
+const LEGACY_LABEL_FIELDS: &[(&str, &str)] = &[
+    (
+        "world",
+        "world is not supported in v2; use created_world_id or home_world_id",
+    ),
+    (
+        "category",
+        "category is not supported in v2; use category_id",
+    ),
+    ("duty", "duty is not supported in v2; use duty_id"),
+    ("jobs", "jobs is not supported in v2; use job_ids"),
+    ("datacenter", "datacenter is not supported in phase-1 v2"),
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListingsQuery {
+    pub page: usize,
+    pub per_page: usize,
+    pub created_world_id: Option<u32>,
+    pub home_world_id: Option<u32>,
+    pub category_id: Option<u32>,
+    pub duty_id: Option<u32>,
+    pub job_ids: Vec<u32>,
+    pub search: Option<String>,
+}
+
+impl Default for ListingsQuery {
+    fn default() -> Self {
+        Self {
+            page: DEFAULT_PAGE,
+            per_page: DEFAULT_PER_PAGE,
+            created_world_id: None,
+            home_world_id: None,
+            category_id: None,
+            duty_id: None,
+            job_ids: Vec::new(),
+            search: None,
+        }
+    }
+}
+
+pub fn parse_listings_query(
+    params: &HashMap<String, String>,
+) -> Result<ListingsQuery, ErrorEnvelope> {
+    for field in sorted_keys(params) {
+        if let Some((_, message)) = LEGACY_LABEL_FIELDS
+            .iter()
+            .find(|(legacy, _)| field == *legacy)
+        {
+            return Err(ErrorEnvelope::invalid_query(field.clone(), *message));
+        }
+
+        if !SUPPORTED_QUERY_FIELDS
+            .iter()
+            .any(|supported| field == *supported)
+        {
+            return Err(ErrorEnvelope::invalid_query(
+                field.clone(),
+                format!("{field} is not a supported query parameter"),
+            ));
+        }
+    }
+
+    let mut query = ListingsQuery::default();
+
+    if let Some(value) = params.get("page") {
+        query.page = parse_page(value)?;
+    }
+
+    if let Some(value) = params.get("per_page") {
+        query.per_page = parse_per_page(value)?;
+    }
+
+    query.created_world_id = parse_optional_u32(params, "created_world_id")?;
+    query.home_world_id = parse_optional_u32(params, "home_world_id")?;
+    query.category_id = parse_optional_u32(params, "category_id")?;
+    query.duty_id = parse_optional_u32(params, "duty_id")?;
+
+    if let Some(value) = params.get("job_ids") {
+        query.job_ids = parse_job_ids(value)?;
+    }
+
+    if let Some(value) = params.get("search") {
+        if !value.is_empty() {
+            query.search = Some(value.clone());
+        }
+    }
+
+    Ok(query)
+}
+
+fn sorted_keys(params: &HashMap<String, String>) -> Vec<String> {
+    let mut keys = params.keys().cloned().collect::<Vec<_>>();
+    keys.sort();
+    keys
+}
+
+fn parse_page(value: &str) -> Result<usize, ErrorEnvelope> {
+    let page = value
+        .parse::<usize>()
+        .map_err(|_| ErrorEnvelope::invalid_query("page", "page must be a positive integer"))?;
+
+    if page == 0 {
+        return Err(ErrorEnvelope::invalid_query(
+            "page",
+            "page must be a positive integer",
+        ));
+    }
+
+    Ok(page)
+}
+
+fn parse_per_page(value: &str) -> Result<usize, ErrorEnvelope> {
+    let per_page = value.parse::<usize>().map_err(|_| {
+        ErrorEnvelope::invalid_query("per_page", "per_page must be between 1 and 100")
+    })?;
+
+    if !(1..=MAX_PER_PAGE).contains(&per_page) {
+        return Err(ErrorEnvelope::invalid_query(
+            "per_page",
+            "per_page must be between 1 and 100",
+        ));
+    }
+
+    Ok(per_page)
+}
+
+fn parse_optional_u32(
+    params: &HashMap<String, String>,
+    field: &'static str,
+) -> Result<Option<u32>, ErrorEnvelope> {
+    params
+        .get(field)
+        .map(|value| {
+            value.parse::<u32>().map_err(|_| {
+                ErrorEnvelope::invalid_query(field, format!("{field} must be an unsigned integer"))
+            })
+        })
+        .transpose()
+}
+
+fn parse_job_ids(value: &str) -> Result<Vec<u32>, ErrorEnvelope> {
+    if value.is_empty() {
+        return Err(ErrorEnvelope::invalid_query(
+            "job_ids",
+            "job_ids must be a comma-separated list of unsigned integers",
+        ));
+    }
+
+    value
+        .split(',')
+        .map(|segment| {
+            let trimmed = segment.trim();
+            if trimmed.is_empty() {
+                return Err(ErrorEnvelope::invalid_query(
+                    "job_ids",
+                    "job_ids must be a comma-separated list of unsigned integers",
+                ));
+            }
+
+            trimmed.parse::<u32>().map_err(|_| {
+                ErrorEnvelope::invalid_query(
+                    "job_ids",
+                    "job_ids must be a comma-separated list of unsigned integers",
+                )
+            })
+        })
+        .collect()
+}

--- a/server/src/web/v2/id_inventory.rs
+++ b/server/src/web/v2/id_inventory.rs
@@ -1,0 +1,174 @@
+use ffxiv_types_cn::{jobs::ClassJob, Role};
+
+use crate::{
+    ffxiv,
+    listing::{ConditionFlags, DutyCategory, DutyType, JobFlags, LootRuleFlags, ObjectiveFlags},
+};
+
+pub const PHASE_ONE_PRIMARY_EXPOSES_DATACENTER: bool = false;
+
+pub const ROLE_ID_DPS: u32 = 1;
+pub const ROLE_ID_HEALER: u32 = 2;
+pub const ROLE_ID_TANK: u32 = 3;
+
+pub const CATEGORY_IDS: [u32; 16] = [
+    0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768,
+];
+
+pub const DUTY_TYPE_IDS: [u32; 3] = [0, 1, 2];
+
+pub const ROLE_IDS: [u32; 3] = [ROLE_ID_DPS, ROLE_ID_HEALER, ROLE_ID_TANK];
+pub const OBJECTIVE_IDS: [u32; 3] = [
+    ObjectiveFlags::DUTY_COMPLETION.bits(),
+    ObjectiveFlags::PRACTICE.bits(),
+    ObjectiveFlags::LOOT.bits(),
+];
+pub const CONDITION_IDS: [u32; 3] = [
+    ConditionFlags::DUTY_COMPLETE.bits(),
+    ConditionFlags::DUTY_INCOMPLETE.bits(),
+    ConditionFlags::DUTY_COMPLETE_WEEKLY_REWARD_UNCLAIMED.bits(),
+];
+pub const LOOT_RULE_IDS: [u32; 4] = [
+    LootRuleFlags::NONE.bits(),
+    LootRuleFlags::GREED_ONLY.bits(),
+    LootRuleFlags::LOOTMASTER.bits(),
+    LootRuleFlags::GREED_ONLY.bits() | LootRuleFlags::LOOTMASTER.bits(),
+];
+
+pub fn world_ids() -> Vec<u32> {
+    sorted_ids(ffxiv::WORLDS.keys().copied().collect())
+}
+
+pub fn world_id(world_id: u16) -> u32 {
+    u32::from(world_id)
+}
+
+pub fn category_id(category: DutyCategory) -> u32 {
+    category.as_u32()
+}
+
+pub fn duty_id(duty_id: u16) -> u32 {
+    u32::from(duty_id)
+}
+
+pub fn duty_type_id(duty_type: DutyType) -> u32 {
+    u32::from(duty_type.as_u8())
+}
+
+pub fn job_ids() -> Vec<u32> {
+    accepted_job_ids(JobFlags::all())
+}
+
+pub fn accepted_job_flag_bits(job_id: u32) -> Option<u32> {
+    accepted_job_flag(job_id).map(|job_flag| job_flag.bits())
+}
+
+pub fn slot_accepts_job_id(flags: JobFlags, job_id: u32) -> bool {
+    accepted_job_flag(job_id).is_some_and(|job_flag| flags.intersects(job_flag))
+}
+
+pub fn filled_job_id(job_id: u8) -> Option<u32> {
+    let job_id = u32::from(job_id);
+    ffxiv::JOBS.contains_key(&job_id).then_some(job_id)
+}
+
+pub fn accepted_job_ids(flags: JobFlags) -> Vec<u32> {
+    flags
+        .classjobs()
+        .into_iter()
+        .filter_map(job_id_for_classjob)
+        .collect()
+}
+
+pub fn role_id(role: Role) -> u32 {
+    match role {
+        Role::Dps => ROLE_ID_DPS,
+        Role::Healer => ROLE_ID_HEALER,
+        Role::Tank => ROLE_ID_TANK,
+    }
+}
+
+pub fn role_id_for_job_id(job_id: u32) -> Option<u32> {
+    ffxiv::JOBS.get(&job_id)?.role().map(role_id)
+}
+
+pub fn role_id_for_job_ids(job_ids: &[u32]) -> Option<u32> {
+    let mut role_ids = job_ids
+        .iter()
+        .filter_map(|job_id| role_id_for_job_id(*job_id));
+    let first = role_ids.next()?;
+    role_ids.all(|role_id| role_id == first).then_some(first)
+}
+
+pub fn objective_ids(flags: ObjectiveFlags) -> Vec<u32> {
+    flag_ids(flags.bits(), &OBJECTIVE_IDS)
+}
+
+pub fn condition_ids(flags: ConditionFlags) -> Vec<u32> {
+    flag_ids(flags.bits() & !ConditionFlags::NONE.bits(), &CONDITION_IDS)
+}
+
+pub fn loot_rule_id(flags: LootRuleFlags) -> u32 {
+    flags.bits()
+}
+
+fn job_id_for_classjob(class_job: ClassJob) -> Option<u32> {
+    ffxiv::JOBS
+        .iter()
+        .find_map(|(job_id, candidate)| (*candidate == class_job).then_some(*job_id))
+}
+
+fn accepted_job_flag(job_id: u32) -> Option<JobFlags> {
+    all_job_flags().into_iter().find(
+        |flag| matches!(accepted_job_ids(*flag).as_slice(), [candidate] if *candidate == job_id),
+    )
+}
+
+fn all_job_flags() -> [JobFlags; 31] {
+    [
+        JobFlags::GLADIATOR,
+        JobFlags::PUGILIST,
+        JobFlags::MARAUDER,
+        JobFlags::LANCER,
+        JobFlags::ARCHER,
+        JobFlags::CONJURER,
+        JobFlags::THAUMATURGE,
+        JobFlags::PALADIN,
+        JobFlags::MONK,
+        JobFlags::WARRIOR,
+        JobFlags::DRAGOON,
+        JobFlags::BARD,
+        JobFlags::WHITE_MAGE,
+        JobFlags::BLACK_MAGE,
+        JobFlags::ARCANIST,
+        JobFlags::SUMMONER,
+        JobFlags::SCHOLAR,
+        JobFlags::ROGUE,
+        JobFlags::NINJA,
+        JobFlags::MACHINIST,
+        JobFlags::DARK_KNIGHT,
+        JobFlags::ASTROLOGIAN,
+        JobFlags::SAMURAI,
+        JobFlags::RED_MAGE,
+        JobFlags::BLUE_MAGE,
+        JobFlags::GUNBREAKER,
+        JobFlags::DANCER,
+        JobFlags::REAPER,
+        JobFlags::SAGE,
+        JobFlags::VIPER,
+        JobFlags::PICTOMANCER,
+    ]
+}
+
+fn flag_ids(flags: u32, known_ids: &[u32]) -> Vec<u32> {
+    known_ids
+        .iter()
+        .copied()
+        .filter(|id| flags & id != 0)
+        .collect()
+}
+
+fn sorted_ids(mut ids: Vec<u32>) -> Vec<u32> {
+    ids.sort_unstable();
+    ids
+}

--- a/server/src/web/v2/listings.rs
+++ b/server/src/web/v2/listings.rs
@@ -1,0 +1,700 @@
+use std::{collections::HashMap, convert::Infallible, sync::Arc};
+
+use chrono::{Duration, Utc};
+use mongodb::bson::{doc, Document};
+use serde_json::{Map, Value};
+use tokio_stream::StreamExt;
+use warp::{filters::BoxedFilter, http::StatusCode, reply::Response, Filter, Reply};
+
+use crate::{
+    listing::{PartyFinderListing, SearchAreaFlags},
+    listing_container::QueriedListing,
+    sestring_ext::SeStringExt,
+    web::State,
+};
+
+use super::{
+    contracts::{
+        CollectionEnvelope, ErrorEnvelope, ListingCollectionResponse, ListingDetail,
+        ListingMemberResponse, ListingSlot, ListingSummary, Pagination,
+    },
+    filters::{parse_listings_query, ListingsQuery},
+    id_inventory,
+};
+
+const ACTIVE_UPDATE_WINDOW: Duration = Duration::minutes(5);
+const RECENT_LISTING_WINDOW: Duration = Duration::hours(2);
+
+pub fn routes(state: Arc<State>) -> BoxedFilter<(Response,)> {
+    collection_route(Arc::clone(&state))
+        .or(member_route(state))
+        .unify()
+        .boxed()
+}
+
+fn collection_route(state: Arc<State>) -> BoxedFilter<(Response,)> {
+    warp::path!("api" / "v2" / "listings")
+        .and(warp::path::end())
+        .and(warp::get())
+        .and(
+            warp::query::<HashMap<String, String>>()
+                .or(warp::any().map(HashMap::new))
+                .unify(),
+        )
+        .and(warp::any().map(move || state.clone()))
+        .and_then(collection)
+        .boxed()
+}
+
+fn member_route(state: Arc<State>) -> BoxedFilter<(Response,)> {
+    warp::path!("api" / "v2" / "listings" / u32)
+        .and(warp::path::end())
+        .and(warp::get())
+        .and(warp::any().map(move || state.clone()))
+        .and_then(member)
+        .boxed()
+}
+
+pub(crate) fn collection_route_for_tests() -> BoxedFilter<(Response,)> {
+    warp::path!("api" / "v2" / "listings")
+        .and(warp::path::end())
+        .and(warp::get())
+        .and(
+            warp::query::<HashMap<String, String>>()
+                .or(warp::any().map(HashMap::new))
+                .unify(),
+        )
+        .and_then(collection_with_empty_documents)
+        .boxed()
+}
+
+#[cfg(test)]
+pub(crate) fn collection_response_from_raw_documents_for_tests(
+    query: ListingsQuery,
+    documents: Vec<Document>,
+) -> Response {
+    collection_response_from_raw_documents(query, documents)
+}
+
+async fn collection(
+    query: HashMap<String, String>,
+    state: Arc<State>,
+) -> Result<Response, Infallible> {
+    match parse_listings_query(&query) {
+        Ok(query) => Ok(collection_response(query, state).await.into_response()),
+        Err(error) => Ok(invalid_query_reply(error).into_response()),
+    }
+}
+
+async fn collection_with_empty_documents(
+    query: HashMap<String, String>,
+) -> Result<Response, Infallible> {
+    match parse_listings_query(&query) {
+        Ok(query) => Ok(warp::reply::json(&collection_response_from_documents(query, []))
+            .into_response()),
+        Err(error) => Ok(invalid_query_reply(error).into_response()),
+    }
+}
+
+pub(crate) fn member_route_for_tests(
+    documents: Vec<QueriedListing>,
+) -> BoxedFilter<(Response,)> {
+    let documents = Arc::new(documents);
+
+    warp::path!("api" / "v2" / "listings" / u32)
+        .and(warp::path::end())
+        .and(warp::get())
+        .and(warp::any().map(move || Arc::clone(&documents)))
+        .and_then(member_from_documents)
+        .boxed()
+}
+
+async fn member(id: u32, state: Arc<State>) -> Result<Response, Infallible> {
+    Ok(member_response(id, state).await)
+}
+
+async fn member_from_documents(
+    id: u32,
+    documents: Arc<Vec<QueriedListing>>,
+) -> Result<Response, Infallible> {
+    Ok(member_response_from_documents(id, documents.iter()))
+}
+
+async fn member_response(id: u32, state: Arc<State>) -> Response {
+    let aggregation = state.collection().aggregate(member_pipeline(id), None).await;
+
+    match aggregation {
+        Ok(mut cursor) => {
+            let mut documents = Vec::new();
+
+            while let Some(result) = cursor.next().await {
+                match result {
+                    Ok(document) => match mongodb::bson::from_document::<QueriedListing>(document) {
+                        Ok(document) => documents.push(document),
+                        Err(error) => {
+                            eprintln!("{error:#?}");
+                            return internal_error_reply().into_response();
+                        }
+                    },
+                    Err(error) => {
+                        eprintln!("{error:#?}");
+                        return internal_error_reply().into_response();
+                    }
+                }
+            }
+
+            member_response_from_documents(id, documents.iter())
+        }
+        Err(error) => {
+            eprintln!("{error:#?}");
+            internal_error_reply().into_response()
+        }
+    }
+}
+
+fn member_pipeline(id: u32) -> Vec<Document> {
+    vec![
+        doc! {
+            "$match": {
+                "updated_at": { "$gte": Utc::now() - RECENT_LISTING_WINDOW },
+                "listing.id": id,
+                "listing.search_area": { "$bitsAllClear": SearchAreaFlags::PRIVATE.bits() as i32 },
+            }
+        },
+        doc! {
+            "$set": {
+                "time_left": {
+                    "$divide": [
+                        {
+                            "$subtract": [
+                                { "$multiply": ["$listing.seconds_remaining", 1000] },
+                                { "$subtract": ["$$NOW", "$updated_at"] },
+                            ]
+                        },
+                        1000,
+                    ]
+                },
+                "minutes_since_update": {
+                    "$divide": [
+                        { "$subtract": ["$$NOW", "$updated_at"] },
+                        60000,
+                    ]
+                },
+                "updated_minute": {
+                    "$dateTrunc": {
+                        "date": "$updated_at",
+                        "unit": "minute",
+                        "binSize": 5,
+                    }
+                },
+            }
+        },
+        doc! {
+            "$sort": {
+                "updated_at": -1,
+            }
+        },
+    ]
+}
+
+pub(crate) fn member_response_from_documents<'a>(
+    id: u32,
+    documents: impl IntoIterator<Item = &'a QueriedListing>,
+) -> Response {
+    match resolve_listing_detail(id, documents) {
+        Some(detail) => warp::reply::json(&ListingMemberResponse { data: detail }).into_response(),
+        None => not_found_reply(id).into_response(),
+    }
+}
+
+fn not_found_reply(id: u32) -> impl Reply {
+    let mut details = Map::new();
+    details.insert("id".into(), Value::from(id));
+
+    warp::reply::with_status(
+        warp::reply::json(&ErrorEnvelope::new(
+            "not_found",
+            "Listing not found",
+            details,
+        )),
+        StatusCode::NOT_FOUND,
+    )
+}
+
+fn invalid_query_reply(error: ErrorEnvelope) -> impl Reply {
+    warp::reply::with_status(warp::reply::json(&error), StatusCode::BAD_REQUEST)
+}
+
+async fn collection_response(query: ListingsQuery, state: Arc<State>) -> Response {
+    if query_demands_empty_collection(&query) {
+        return warp::reply::json(&empty_collection_response(&query)).into_response();
+    }
+
+    let aggregation = state.collection().aggregate(collection_pipeline(&query), None).await;
+
+    match aggregation {
+        Ok(mut cursor) => {
+            let mut documents = Vec::new();
+
+            while let Some(result) = cursor.next().await {
+                match result {
+                    Ok(document) => match decode_queried_listing(document) {
+                        Ok(document) => documents.push(document),
+                        Err(()) => return internal_error_reply().into_response(),
+                    },
+                    Err(error) => {
+                        eprintln!("{error:#?}");
+                        return internal_error_reply().into_response();
+                    }
+                }
+            }
+
+            collection_response_from_decoded_documents(query, documents)
+        }
+        Err(error) => {
+            eprintln!("{error:#?}");
+            internal_error_reply().into_response()
+        }
+    }
+}
+
+fn internal_error_reply() -> impl Reply {
+    warp::reply::with_status(
+        warp::reply::json(&ErrorEnvelope::new(
+            "internal_error",
+            "Failed to load API v2 listings",
+            Default::default(),
+        )),
+        StatusCode::INTERNAL_SERVER_ERROR,
+    )
+}
+
+pub(crate) fn collection_pipeline(query: &ListingsQuery) -> Vec<Document> {
+    let mut pipeline = vec![doc! {
+        "$match": {
+            "updated_at": { "$gte": Utc::now() - RECENT_LISTING_WINDOW },
+            "listing.search_area": { "$bitsAllClear": SearchAreaFlags::PRIVATE.bits() as i32 },
+        }
+    }];
+
+    if let Some(created_world_id) = query.created_world_id {
+        pipeline.push(doc! {
+            "$match": {
+                "listing.created_world": created_world_id as i32,
+            }
+        });
+    }
+
+    if let Some(home_world_id) = query.home_world_id {
+        pipeline.push(doc! {
+            "$match": {
+                "listing.home_world": home_world_id as i32,
+            }
+        });
+    }
+
+    if let Some(category_id) = query.category_id {
+        pipeline.push(doc! {
+            "$match": {
+                "listing.category": category_id as i32,
+            }
+        });
+    }
+
+    if let Some(duty_id) = query.duty_id {
+        pipeline.push(doc! {
+            "$match": {
+                "listing.duty": duty_id as i32,
+            }
+        });
+    }
+
+    if !query.job_ids.is_empty() {
+        let job_conditions = query
+            .job_ids
+            .iter()
+            .filter_map(|job_id| id_inventory::accepted_job_flag_bits(*job_id))
+            .map(|job_flag_bits| {
+                doc! {
+                    "listing.slots": {
+                        "$elemMatch": {
+                            "accepting": {
+                                "$bitsAllSet": job_flag_bits as i64
+                            }
+                        }
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        pipeline.push(doc! {
+            "$match": {
+                "$or": job_conditions,
+            }
+        });
+    }
+
+    pipeline.extend([
+        doc! {
+            "$set": {
+                "time_left": {
+                    "$divide": [
+                        {
+                            "$subtract": [
+                                { "$multiply": ["$listing.seconds_remaining", 1000] },
+                                { "$subtract": ["$$NOW", "$updated_at"] },
+                            ]
+                        },
+                        1000,
+                    ]
+                },
+                "minutes_since_update": {
+                    "$divide": [
+                        { "$subtract": ["$$NOW", "$updated_at"] },
+                        60000,
+                    ]
+                },
+            }
+        },
+        doc! {
+            "$match": {
+                "$and": [
+                    { "time_left": { "$gte": 0 } },
+                    { "minutes_since_update": { "$lt": 5.0 } },
+                ]
+            }
+        },
+        doc! {
+            "$sort": {
+                "updated_at": -1,
+            }
+        },
+        doc! {
+            "$group": {
+                "_id": "$listing.content_id_lower",
+                "doc": { "$first": "$$ROOT" },
+            }
+        },
+        doc! {
+            "$replaceRoot": { "newRoot": "$doc" }
+        },
+        doc! {
+            "$set": {
+                "updated_minute": {
+                    "$dateTrunc": {
+                        "date": "$updated_at",
+                        "unit": "minute",
+                        "binSize": 5,
+                    }
+                }
+            }
+        },
+        doc! {
+            "$sort": {
+                "updated_minute": -1,
+                "listing.category": -1,
+                "time_left": 1,
+            }
+        },
+    ]);
+
+    pipeline
+}
+
+pub(crate) fn collection_response_from_documents<'a>(
+    query: ListingsQuery,
+    documents: impl IntoIterator<Item = &'a QueriedListing>,
+) -> ListingCollectionResponse {
+    let filtered = documents
+        .into_iter()
+        .filter(|document| matches_query(document, &query))
+        .filter_map(project_listing_summary)
+        .collect::<Vec<_>>();
+
+    paginated_collection_response(query, filtered)
+}
+
+fn paginated_collection_response(
+    query: ListingsQuery,
+    filtered: Vec<ListingSummary>,
+) -> ListingCollectionResponse {
+    let total = filtered.len();
+    let total_pages = total_pages(total, query.per_page);
+    let data = if query.page > total_pages && total > 0 {
+        Vec::new()
+    } else {
+        filtered
+            .into_iter()
+            .skip((query.page - 1) * query.per_page)
+            .take(query.per_page)
+            .collect()
+    };
+
+    CollectionEnvelope {
+        data,
+        pagination: Pagination {
+            total,
+            page: query.page,
+            per_page: query.per_page,
+            total_pages,
+        },
+    }
+}
+
+fn empty_collection_response(query: &ListingsQuery) -> ListingCollectionResponse {
+    CollectionEnvelope {
+        data: Vec::new(),
+        pagination: Pagination {
+            total: 0,
+            page: query.page,
+            per_page: query.per_page,
+            total_pages: 0,
+        },
+    }
+}
+
+fn total_pages(total: usize, per_page: usize) -> usize {
+    if total == 0 {
+        0
+    } else {
+        (total + per_page - 1) / per_page
+    }
+}
+
+fn query_demands_empty_collection(query: &ListingsQuery) -> bool {
+    query
+        .created_world_id
+        .is_some_and(|world_id| !id_inventory::world_ids().contains(&world_id))
+        || query
+            .home_world_id
+            .is_some_and(|world_id| !id_inventory::world_ids().contains(&world_id))
+        || query
+            .category_id
+            .is_some_and(|category_id| !id_inventory::CATEGORY_IDS.contains(&category_id))
+        || query.duty_id.is_some_and(|duty_id| duty_id > u16::MAX as u32)
+        || query
+            .job_ids
+            .iter()
+            .any(|job_id| !id_inventory::job_ids().contains(job_id))
+}
+
+fn matches_query(document: &QueriedListing, query: &ListingsQuery) -> bool {
+    let listing = match visible_listing(document) {
+        Some(listing) => listing,
+        None => return false,
+    };
+
+    query
+        .created_world_id
+        .is_none_or(|world_id| id_inventory::world_id(listing.created_world) == world_id)
+        && query
+            .home_world_id
+            .is_none_or(|world_id| id_inventory::world_id(listing.home_world) == world_id)
+        && query
+            .category_id
+            .is_none_or(|category_id| id_inventory::category_id(listing.category) == category_id)
+        && query
+            .duty_id
+            .is_none_or(|duty_id| id_inventory::duty_id(listing.duty) == duty_id)
+        && matches_job_ids(listing, &query.job_ids)
+        && matches_search(listing, query.search.as_deref())
+}
+
+fn matches_job_ids(listing: &PartyFinderListing, job_ids: &[u32]) -> bool {
+    job_ids.is_empty()
+        || listing.slots.iter().any(|slot| {
+            job_ids
+                .iter()
+                .any(|job_id| id_inventory::slot_accepts_job_id(slot.accepting, *job_id))
+        })
+}
+
+fn collection_response_from_raw_documents(query: ListingsQuery, documents: Vec<Document>) -> Response {
+    let mut decoded_documents = Vec::new();
+
+    for document in documents {
+        match decode_queried_listing(document) {
+            Ok(document) => decoded_documents.push(document),
+            Err(()) => return internal_error_reply().into_response(),
+        }
+    }
+
+    collection_response_from_decoded_documents(query, decoded_documents)
+}
+
+fn collection_response_from_decoded_documents(
+    query: ListingsQuery,
+    documents: Vec<QueriedListing>,
+) -> Response {
+    warp::reply::json(&collection_response_from_documents(query, documents.iter())).into_response()
+}
+
+fn decode_queried_listing(document: Document) -> Result<QueriedListing, ()> {
+    mongodb::bson::from_document::<QueriedListing>(document).map_err(|error| {
+        eprintln!("{error:#?}");
+    })
+}
+
+fn matches_search(listing: &PartyFinderListing, search: Option<&str>) -> bool {
+    let Some(search) = search else {
+        return true;
+    };
+
+    let search = search.to_lowercase();
+    let player_name = listing
+        .name
+        .full_text(&crate::ffxiv::Language::ChineseSimplified)
+        .to_lowercase();
+    let description = listing
+        .description
+        .full_text(&crate::ffxiv::Language::ChineseSimplified)
+        .to_lowercase();
+
+    player_name.contains(&search) || description.contains(&search)
+}
+
+pub(crate) fn project_listing_summaries<'a>(
+    documents: impl IntoIterator<Item = &'a QueriedListing>,
+) -> Vec<ListingSummary> {
+    documents
+        .into_iter()
+        .filter_map(project_listing_summary)
+        .collect()
+}
+
+pub(crate) fn project_listing_summary(document: &QueriedListing) -> Option<ListingSummary> {
+    let listing = visible_listing(document)?;
+
+    Some(ListingSummary {
+        id: listing.id,
+        player_name: listing
+            .name
+            .full_text(&crate::ffxiv::Language::ChineseSimplified)
+            .into(),
+        description: listing
+            .description
+            .full_text(&crate::ffxiv::Language::ChineseSimplified)
+            .into(),
+        created_world_id: id_inventory::world_id(listing.created_world),
+        home_world_id: id_inventory::world_id(listing.home_world),
+        category_id: id_inventory::category_id(listing.category),
+        duty_id: id_inventory::duty_id(listing.duty),
+        duty_type_id: id_inventory::duty_type_id(listing.duty_type),
+        min_item_level: listing.min_item_level,
+        slots_filled: count_slots_filled(listing),
+        slots_available: listing.slots_available,
+        time_left_seconds: time_left_seconds(document.time_left),
+        updated_at: document.updated_at.to_rfc3339(),
+        is_cross_world: is_cross_world(listing),
+        beginners_welcome: listing.beginners_welcome,
+    })
+}
+
+pub(crate) fn resolve_listing_detail<'a>(
+    id: u32,
+    documents: impl IntoIterator<Item = &'a QueriedListing>,
+) -> Option<ListingDetail> {
+    let mut selected: Option<&QueriedListing> = None;
+
+    for document in documents {
+        let Some(listing) = visible_listing(document) else {
+            continue;
+        };
+
+        if listing.id != id {
+            continue;
+        }
+
+        match selected {
+            Some(current) if document.updated_at <= current.updated_at => {}
+            _ => selected = Some(document),
+        }
+    }
+
+    selected.and_then(project_listing_detail)
+}
+
+pub(crate) fn project_listing_detail(document: &QueriedListing) -> Option<ListingDetail> {
+    let listing = visible_listing(document)?;
+
+    Some(ListingDetail {
+        id: listing.id,
+        player_name: listing
+            .name
+            .full_text(&crate::ffxiv::Language::ChineseSimplified)
+            .into(),
+        description: listing
+            .description
+            .full_text(&crate::ffxiv::Language::ChineseSimplified)
+            .into(),
+        created_world_id: id_inventory::world_id(listing.created_world),
+        home_world_id: id_inventory::world_id(listing.home_world),
+        category_id: id_inventory::category_id(listing.category),
+        duty_id: id_inventory::duty_id(listing.duty),
+        duty_type_id: id_inventory::duty_type_id(listing.duty_type),
+        min_item_level: listing.min_item_level,
+        slots_filled: count_slots_filled(listing),
+        slots_available: listing.slots_available,
+        time_left_seconds: time_left_seconds(document.time_left),
+        updated_at: document.updated_at.to_rfc3339(),
+        is_cross_world: is_cross_world(listing),
+        beginners_welcome: listing.beginners_welcome,
+        objective_ids: id_inventory::objective_ids(listing.objective),
+        condition_ids: id_inventory::condition_ids(listing.conditions),
+        loot_rule_id: id_inventory::loot_rule_id(listing.loot_rules),
+        slots: project_slots(listing),
+    })
+}
+
+fn visible_listing(document: &QueriedListing) -> Option<&PartyFinderListing> {
+    let listing = &document.listing;
+    (!listing.search_area.contains(SearchAreaFlags::PRIVATE) && is_active_listing(document))
+        .then_some(listing)
+}
+
+fn is_active_listing(document: &QueriedListing) -> bool {
+    document.time_left >= 0.0 && document.updated_at >= Utc::now() - ACTIVE_UPDATE_WINDOW
+}
+
+fn time_left_seconds(time_left: f64) -> u32 {
+    time_left.max(0.0).floor() as u32
+}
+
+fn count_slots_filled(listing: &PartyFinderListing) -> usize {
+    listing.jobs_present.iter().filter(|job| **job > 0).count()
+}
+
+fn is_cross_world(listing: &PartyFinderListing) -> bool {
+    listing.search_area.contains(SearchAreaFlags::DATA_CENTRE)
+}
+
+fn project_slots(listing: &PartyFinderListing) -> Vec<ListingSlot> {
+    listing
+        .slots
+        .iter()
+        .take(listing.slots_available as usize)
+        .enumerate()
+        .map(|(index, slot)| {
+            let filled_job_id = listing
+                .jobs_present
+                .get(index)
+                .copied()
+                .and_then(id_inventory::filled_job_id);
+            let accepted_job_ids = filled_job_id
+                .is_none()
+                .then(|| id_inventory::accepted_job_ids(slot.accepting))
+                .unwrap_or_default();
+            let role_id = filled_job_id
+                .and_then(id_inventory::role_id_for_job_id)
+                .or_else(|| id_inventory::role_id_for_job_ids(&accepted_job_ids))
+                .unwrap_or_default();
+
+            ListingSlot {
+                filled: filled_job_id.is_some(),
+                role_id,
+                filled_job_id,
+                accepted_job_ids,
+            }
+        })
+        .collect()
+}

--- a/server/src/web/v2/lookups.rs
+++ b/server/src/web/v2/lookups.rs
@@ -1,0 +1,1 @@
+pub const PHASE_ONE_LOOKUPS_EXPOSED: bool = false;

--- a/server/src/web/v2/mod.rs
+++ b/server/src/web/v2/mod.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+use warp::{filters::BoxedFilter, Reply};
+
+use crate::web::State;
+
+pub mod contracts;
+pub mod filters;
+pub mod id_inventory;
+pub mod listings;
+pub mod lookups;
+
+pub fn routes(state: Arc<State>) -> BoxedFilter<(impl Reply,)> {
+    listings::routes(state)
+}


### PR DESCRIPTION
## Summary
- add phase 1 /api/v2/listings and /api/v2/listings/{id} endpoints with ID-first contracts and no lookup routes
- add v1 regression coverage plus dedicated api v2 contract tests to protect rollout behavior and filtering semantics
- document the phase 1 api v2 surface in README and docs/api-v2.md

## Validation
- cargo test